### PR TITLE
Add grant application states

### DIFF
--- a/db/migrations/20200616090757-application-state.js
+++ b/db/migrations/20200616090757-application-state.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20200616090757-application-state-up.sql'
+  );
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function(err, data) {
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  }).then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20200616090757-application-state-down.sql'
+  );
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function(err, data) {
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  }).then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  version: 1
+};

--- a/db/migrations/20200616091329-application-history.js
+++ b/db/migrations/20200616091329-application-history.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20200616091329-application-history-up.sql'
+  );
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function(err, data) {
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  }).then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20200616091329-application-history-down.sql'
+  );
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function(err, data) {
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  }).then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  version: 1
+};

--- a/db/migrations/20200616094803-add-default-history-entries.js
+++ b/db/migrations/20200616094803-add-default-history-entries.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20200616094803-add-default-history-entries-up.sql'
+  );
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function(err, data) {
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  }).then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20200616094803-add-default-history-entries-down.sql'
+  );
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function(err, data) {
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  }).then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  version: 1
+};

--- a/db/migrations/20200616114442-application-assessment.js
+++ b/db/migrations/20200616114442-application-assessment.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20200616114442-application-assessment-up.sql'
+  );
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function(err, data) {
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  }).then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20200616114442-application-assessment-down.sql'
+  );
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function(err, data) {
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  }).then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  version: 1
+};

--- a/db/migrations/20200616133931-add-default-application-assesment-entries.js
+++ b/db/migrations/20200616133931-add-default-application-assesment-entries.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+ * We receive the dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20200616133931-add-default-application-assesment-entries-up.sql'
+  );
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function(err, data) {
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  }).then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20200616133931-add-default-application-assesment-entries-down.sql'
+  );
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function(err, data) {
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  }).then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  version: 1
+};

--- a/db/migrations/sqls/20200616090757-application-state-down.sql
+++ b/db/migrations/sqls/20200616090757-application-state-down.sql
@@ -1,0 +1,1 @@
+DROP TABLE application_state;

--- a/db/migrations/sqls/20200616090757-application-state-up.sql
+++ b/db/migrations/sqls/20200616090757-application-state-up.sql
@@ -1,0 +1,4 @@
+CREATE TABLE application_state (
+    id INTEGER PRIMARY KEY,
+    description VARCHAR NOT NULL
+);

--- a/db/migrations/sqls/20200616090757-application-state-up.sql
+++ b/db/migrations/sqls/20200616090757-application-state-up.sql
@@ -2,3 +2,18 @@ CREATE TABLE application_state (
     id INTEGER PRIMARY KEY,
     description VARCHAR NOT NULL
 );
+
+
+INSERT INTO application_state(id, description) VALUES(1, 'Unprocessed');
+INSERT INTO application_state(id, description) VALUES(2, 'Pre-processing');
+INSERT INTO application_state(id, description) VALUES(3, 'Pre-processing - Awaiting info');
+INSERT INTO application_state(id, description) VALUES(4, 'Pre-processed');
+INSERT INTO application_state(id, description) VALUES(5, 'Pre-processing - Rejected');
+INSERT INTO application_state(id, description) VALUES(6, 'Processing');
+INSERT INTO application_state(id, description) VALUES(7, 'Refer to Finance');
+INSERT INTO application_state(id, description) VALUES(8, 'Refer to Manager');
+INSERT INTO application_state(id, description) VALUES(9, 'Processing - Awaiting info');
+INSERT INTO application_state(id, description) VALUES(10, 'Processed - Panel Review');
+INSERT INTO application_state(id, description) VALUES(11, 'Processed - Rejected');
+INSERT INTO application_state(id, description) VALUES(12, 'Panel Approved');
+INSERT INTO application_state(id, description) VALUES(13, 'Panel Rejected');

--- a/db/migrations/sqls/20200616091329-application-history-down.sql
+++ b/db/migrations/sqls/20200616091329-application-history-down.sql
@@ -1,0 +1,1 @@
+DROP TABLE application_history;

--- a/db/migrations/sqls/20200616091329-application-history-up.sql
+++ b/db/migrations/sqls/20200616091329-application-history-up.sql
@@ -1,7 +1,6 @@
 CREATE TABLE application_history (
     id serial PRIMARY KEY,
     grant_application_id INTEGER REFERENCES grant_application(id) NOT NULL,
-    application_state_id  INTEGER REFERENCES application_state(id) NOT NULL,
     date_time_recorded TIMESTAMP DEFAULT NOW(),
     user_recorded VARCHAR NOT NULL,
     notes VARCHAR

--- a/db/migrations/sqls/20200616091329-application-history-up.sql
+++ b/db/migrations/sqls/20200616091329-application-history-up.sql
@@ -4,5 +4,5 @@ CREATE TABLE application_history (
     application_state_id  INTEGER REFERENCES application_state(id) NOT NULL,
     date_time_recorded TIMESTAMP DEFAULT NOW(),
     user_recorded VARCHAR NOT NULL,
-    comment VARCHAR
+    notes VARCHAR
 );

--- a/db/migrations/sqls/20200616091329-application-history-up.sql
+++ b/db/migrations/sqls/20200616091329-application-history-up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE application_history (
+    id serial PRIMARY KEY,
+    grant_application_id INTEGER REFERENCES grant_application(id) NOT NULL,
+    application_state_id  INTEGER REFERENCES application_state(id) NOT NULL,
+    date_time_recorded TIMESTAMP DEFAULT NOW(),
+    user_recorded VARCHAR NOT NULL,
+    comment VARCHAR
+);

--- a/db/migrations/sqls/20200616094803-add-default-history-entries-down.sql
+++ b/db/migrations/sqls/20200616094803-add-default-history-entries-down.sql
@@ -1,0 +1,1 @@
+DELETE FROM application_history;

--- a/db/migrations/sqls/20200616094803-add-default-history-entries-up.sql
+++ b/db/migrations/sqls/20200616094803-add-default-history-entries-up.sql
@@ -1,0 +1,6 @@
+INSERT INTO application_history
+(grant_application_id, application_state_id, date_time_recorded, user_recorded, notes)
+SELECT ga.id, 1, ga.date_time_recorded, 'system', 'Application Received'
+FROM grant_application ga
+WHERE ga.id NOT IN (select distinct grant_application_id from application_history)
+ORDER BY ga.id;

--- a/db/migrations/sqls/20200616094803-add-default-history-entries-up.sql
+++ b/db/migrations/sqls/20200616094803-add-default-history-entries-up.sql
@@ -1,6 +1,6 @@
 INSERT INTO application_history
-(grant_application_id, application_state_id, date_time_recorded, user_recorded, notes)
-SELECT ga.id, 1, ga.date_time_recorded, 'system', 'Application Received'
+(grant_application_id, date_time_recorded, user_recorded, notes)
+SELECT ga.id, ga.date_time_recorded, 'system', 'Application Received'
 FROM grant_application ga
 WHERE ga.id NOT IN (SELECT DISTINCT grant_application_id FROM application_history)
 ORDER BY ga.id;

--- a/db/migrations/sqls/20200616094803-add-default-history-entries-up.sql
+++ b/db/migrations/sqls/20200616094803-add-default-history-entries-up.sql
@@ -2,5 +2,5 @@ INSERT INTO application_history
 (grant_application_id, application_state_id, date_time_recorded, user_recorded, notes)
 SELECT ga.id, 1, ga.date_time_recorded, 'system', 'Application Received'
 FROM grant_application ga
-WHERE ga.id NOT IN (select distinct grant_application_id from application_history)
+WHERE ga.id NOT IN (SELECT DISTINCT grant_application_id FROM application_history)
 ORDER BY ga.id;

--- a/db/migrations/sqls/20200616114442-application-assessment-down.sql
+++ b/db/migrations/sqls/20200616114442-application-assessment-down.sql
@@ -1,0 +1,1 @@
+DROP TABLE application_assessment;

--- a/db/migrations/sqls/20200616114442-application-assessment-up.sql
+++ b/db/migrations/sqls/20200616114442-application-assessment-up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE application_assessment (
+    id serial PRIMARY KEY,
+    grant_application_id INTEGER REFERENCES grant_application(id) NOT NULL,
+    application_state_id  INTEGER REFERENCES application_state(id) NOT NULL,
+    validations TEXT
+);
+
+CREATE UNIQUE INDEX grant_application_id_idx ON application_assessment(grant_application_id);

--- a/db/migrations/sqls/20200616133931-add-default-application-assesment-entries-down.sql
+++ b/db/migrations/sqls/20200616133931-add-default-application-assesment-entries-down.sql
@@ -1,0 +1,1 @@
+DELETE FROM application_assessment;

--- a/db/migrations/sqls/20200616133931-add-default-application-assesment-entries-up.sql
+++ b/db/migrations/sqls/20200616133931-add-default-application-assesment-entries-up.sql
@@ -1,0 +1,6 @@
+INSERT INTO application_assessment
+(grant_application_id, application_state_id, validations)
+SELECT ga.id, 1, '{}'
+FROM grant_application ga
+WHERE ga.id NOT IN (SELECT DISTINCT grant_application_id FROM application_assessment)
+ORDER BY ga.id;

--- a/db/seeds.sql
+++ b/db/seeds.sql
@@ -40,4 +40,7 @@ INSERT INTO state_aid_option(id, description) VALUES(2, 'Covid 19 Temporary Fram
 INSERT INTO state_aid_option(id, description) VALUES(3, 'State Aid De Minimis Rule');
 
 INSERT INTO application_state(id, description) VALUES(1, 'Unprocessed');
-INSERT INTO application_state(id, description) VALUES(2, 'Rejected at pre-check');
+INSERT INTO application_state(id, description) VALUES(2, 'Pre-processing');
+INSERT INTO application_state(id, description) VALUES(3, 'Pre-processing - Awaiting info');
+INSERT INTO application_state(id, description) VALUES(4, 'Pre-processed');
+INSERT INTO application_state(id, description) VALUES(5, 'Pre-processing - Rejected');

--- a/db/seeds.sql
+++ b/db/seeds.sql
@@ -38,9 +38,3 @@ INSERT INTO business_size(id, description) VALUES(2, 'Small');
 INSERT INTO state_aid_option(id, description) VALUES(1, 'Not Applicable');
 INSERT INTO state_aid_option(id, description) VALUES(2, 'Covid 19 Temporary Framework Scheme');
 INSERT INTO state_aid_option(id, description) VALUES(3, 'State Aid De Minimis Rule');
-
-INSERT INTO application_state(id, description) VALUES(1, 'Unprocessed');
-INSERT INTO application_state(id, description) VALUES(2, 'Pre-processing');
-INSERT INTO application_state(id, description) VALUES(3, 'Pre-processing - Awaiting info');
-INSERT INTO application_state(id, description) VALUES(4, 'Pre-processed');
-INSERT INTO application_state(id, description) VALUES(5, 'Pre-processing - Rejected');

--- a/db/seeds.sql
+++ b/db/seeds.sql
@@ -38,3 +38,6 @@ INSERT INTO business_size(id, description) VALUES(2, 'Small');
 INSERT INTO state_aid_option(id, description) VALUES(1, 'Not Applicable');
 INSERT INTO state_aid_option(id, description) VALUES(2, 'Covid 19 Temporary Framework Scheme');
 INSERT INTO state_aid_option(id, description) VALUES(3, 'State Aid De Minimis Rule');
+
+INSERT INTO application_state(id, description) VALUES(1, 'Unprocessed');
+INSERT INTO application_state(id, description) VALUES(2, 'Rejected at pre-check');


### PR DESCRIPTION
**What**  
Adds tables to support application processing.

- `application_state` List of possible state values 
- `application_history` Audit log
- `application_assessment` - tracking of assessment tick-lists

**Why**  
To process application grants, the system needs to record grant state changes and preserve the audit of decisions.

**Anything else?**

- Migrations & seeds to be run in staging and production
- **Warning:** Running migrations down will lose the history and audit log.
- To follow:
  - Insert a row into the history table on submission of applications