### PR TITLE
Enable query string forwarding in cloudfront

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -158,7 +158,7 @@ resources:
             MaxTTL: 0
             MinTTL: 0
             ForwardedValues:
-              QueryString: false
+              QueryString: true
               Cookies:
                 Forward: all
           Enabled: true


### PR DESCRIPTION
**What**  
Enables query string parameters to be proxied in Cloudfront

