### PR TITLE
URL encode download URL & redirect to signed download URL

### DIFF
--- a/lib/usecases/applicationDetails.js
+++ b/lib/usecases/applicationDetails.js
@@ -239,7 +239,7 @@ const getDocuments = async (dbInstance, clientGeneratedId) => {
   let documents = [];
 
   documents = documentData.map(row => ({
-    s3Path: row.s3_path,
+    s3Path: encodeURIComponent(row.s3_path),
     documentType: row.document_type
   }));
 

--- a/pages/api/applications/[clientGeneratedId]/document/[s3Path].js
+++ b/pages/api/applications/[clientGeneratedId]/document/[s3Path].js
@@ -7,10 +7,10 @@ export default async (req, res) => {
       // eslint-disable-next-line no-case-declarations
       const s3Path = req.query.s3Path;
       try {
-        const result = { url: await signedUrl({ s3Path }) };
-        res.statusCode = HttpStatus.OK;
-        res.setHeader('Content-Type', 'application/json');
-        res.end(JSON.stringify(result));
+        res.writeHead(HttpStatus.MOVED_PERMANENTLY, {
+          Location: await signedUrl({ s3Path })
+        });
+        res.end();
       } catch (error) {
         console.log('Document Signed URL error:', error, 'request:', req);
         res.statusCode = HttpStatus.INTERNAL_SERVER_ERROR;


### PR DESCRIPTION
**Why**  
So the front end doesn't have to think about how to send the S3 path to the API or think about what do do with the signed URL.