### PR TITLE
Change download URL redirect to 302

### DIFF
--- a/pages/api/applications/[clientGeneratedId]/document/[s3Path].js
+++ b/pages/api/applications/[clientGeneratedId]/document/[s3Path].js
@@ -7,7 +7,7 @@ export default async (req, res) => {
       // eslint-disable-next-line no-case-declarations
       const s3Path = req.query.s3Path;
       try {
-        res.writeHead(HttpStatus.MOVED_PERMANENTLY, {
+        res.writeHead(HttpStatus.MOVED_TEMPORARILY, {
           Location: await signedUrl({ s3Path })
         });
         res.end();


### PR DESCRIPTION
**Why**  
To stop the browser caching the signed download URL.