### PR TITLE
Reduce "white noise" in usecase/listApplications.test.js

### DIFF
--- a/lib/usecases/listApplications.test.js
+++ b/lib/usecases/listApplications.test.js
@@ -83,13 +83,13 @@ describe('listApplications', () => {
     const { error } = await listApplications(container)({});
 
     expect(error).toBeNull();
-    expect(databaseSpy).toHaveBeenCalledWith(expect.anything(), {
-      pageSize: 10,
-      offset: 0,
-      statesFilter: expect.anything(),
-      businessTypeFilter: expect.anything(),
-      grantOfficerFilter: expect.anything()
-    });
+    expect(databaseSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        pageSize: 10,
+        offset: 0
+      })
+    );
   });
 
   test('passes through currentPage and pageSize', async () => {
@@ -101,13 +101,13 @@ describe('listApplications', () => {
     });
 
     expect(error).toBeNull();
-    expect(databaseSpy).toHaveBeenCalledWith(expect.anything(), {
-      pageSize: 3,
-      offset: 3,
-      statesFilter: expect.anything(),
-      businessTypeFilter: expect.anything(),
-      grantOfficerFilter: expect.anything()
-    });
+    expect(databaseSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        pageSize: 3,
+        offset: 3
+      })
+    );
   });
 
   test('defaults sort param to +applicationDate', async () => {
@@ -197,8 +197,6 @@ describe('listApplications', () => {
     expect(databaseSpy).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        offset: expect.any(Number),
-        pageSize: expect.any(Number),
         statesFilter: expect.arrayContaining([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
       })
     );
@@ -218,8 +216,6 @@ describe('listApplications', () => {
     expect(databaseSpy).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        offset: expect.any(Number),
-        pageSize: expect.any(Number),
         statesFilter: expect.arrayContaining([expectedStatus])
       })
     );
@@ -250,9 +246,6 @@ describe('listApplications', () => {
     expect(databaseSpy).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        offset: expect.any(Number),
-        pageSize: expect.any(Number),
-        statesFilter: expect.any(Array),
         businessTypeFilter: expect.arrayContaining([1, 2, 3, 4, 5, 6, 7])
       })
     );
@@ -272,9 +265,6 @@ describe('listApplications', () => {
     expect(databaseSpy).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        offset: expect.any(Number),
-        pageSize: expect.any(Number),
-        statesFilter: expect.any(Array),
         businessTypeFilter: expect.arrayContaining([expectedType])
       })
     );
@@ -309,10 +299,6 @@ describe('listApplications', () => {
     expect(databaseSpy).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        offset: expect.any(Number),
-        pageSize: expect.any(Number),
-        statesFilter: expect.any(Array),
-        businessTypeFilter: expect.any(Array),
         grantOfficerFilter: expect.arrayContaining(expectedGrantOfficers)
       })
     );
@@ -334,10 +320,6 @@ describe('listApplications', () => {
     expect(databaseSpy).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        offset: expect.any(Number),
-        pageSize: expect.any(Number),
-        statesFilter: expect.any(Array),
-        businessTypeFilter: expect.any(Array),
         grantOfficerFilter: expect.arrayContaining([expectedGrantOfficer])
       })
     );


### PR DESCRIPTION
**What**  
Deleted some assert anythings that added no value to the tests they were in and I realised they were not needed to make the tests pass.

**Why**  
Less code to maintain = happy.