### PR TITLE
Leave unvalidated bank numbers blank in payment export

### DIFF
--- a/lib/usecases/patchApplications.js
+++ b/lib/usecases/patchApplications.js
@@ -27,7 +27,7 @@ const patchApplications = ({ getDbInstance }) => async ({ author }) => {
     )
     SELECT
         'D' AS record_type,
-        ga.id AS unique_payment_reference,
+        ga.id + 1000 AS unique_payment_reference, -- Add 100 to avoid conflicts with previous manual references
         ga.client_generated_id,
         bba.account_holder,
         ca.first_line AS contact_address_first_line,
@@ -36,6 +36,7 @@ const patchApplications = ({ getDbInstance }) => async ({ author }) => {
         '' AS contact_address_fourth_line,
         ca.postcode AS contact_address_postcode,
         aa.grant_amount_awarded AS amount_to_pay,
+        aa.validations,
         'B' AS payment_type,
         bba.account_sortcode,
         bba.account_number 
@@ -65,21 +66,28 @@ const patchApplications = ({ getDbInstance }) => async ({ author }) => {
   let appsCsv = '';
 
   if (applications && applications.length > 0) {
-    results = applications.map(application => ({
-      record_type: application.record_type,
-      unique_payment_reference: application.unique_payment_reference + 1000,
-      account_holder: application.account_holder,
-      contact_address_first_line: application.contact_address_first_line,
-      contact_address_second_line: application.contact_address_second_line,
-      contact_address_third_line: application.contact_address_third_line,
-      contact_address_fourth_line: application.contact_address_fourth_line,
-      contact_address_postcode: application.contact_address_postcode,
-      amount_to_pay: application.amount_to_pay,
-      payment_type: application.payment_type,
-      account_sortcode: application.account_sortcode,
-      account_number: application.account_number,
-      client_generated_id: application.client_generated_id
-    }));
+    results = applications.map(application => {
+      const validations = JSON.parse(application.validations);
+      return {
+        record_type: application.record_type,
+        unique_payment_reference: application.unique_payment_reference,
+        account_holder: application.account_holder,
+        contact_address_first_line: application.contact_address_first_line,
+        contact_address_second_line: application.contact_address_second_line,
+        contact_address_third_line: application.contact_address_third_line,
+        contact_address_fourth_line: application.contact_address_fourth_line,
+        contact_address_postcode: application.contact_address_postcode,
+        amount_to_pay: application.amount_to_pay,
+        payment_type: application.payment_type,
+        account_sortcode: validations.businessBankAccount.accountSortcode
+          ? application.account_sortcode
+          : '',
+        account_number: validations.businessBankAccount.accountNumber
+          ? application.account_number
+          : '',
+        client_generated_id: application.client_generated_id
+      };
+    });
 
     appsCsv = await new ObjectsToCsv(results).toString(false);
   }

--- a/lib/usecases/patchApplications.test.js
+++ b/lib/usecases/patchApplications.test.js
@@ -1,6 +1,11 @@
 import patchApplications from './patchApplications';
 
-function createContainerAndDatabaseSpy(numberOfApplicationsInResponse) {
+function createContainerAndDatabaseSpy(
+  numberOfApplicationsInResponse,
+  validationsJSONString = {
+    businessBankAccount: { accountNumber: true, accountSortcode: true }
+  }
+) {
   const databaseSpy = jest.fn(() => {
     const databaseResponse = [];
     for (let count = 1; count <= numberOfApplicationsInResponse; count++) {
@@ -17,7 +22,8 @@ function createContainerAndDatabaseSpy(numberOfApplicationsInResponse) {
         payment_type: 'B',
         account_sortcode: `sort code${count}`,
         account_number: `account number${count}`,
-        client_generated_id: `ClientGeneratedId${count}`
+        client_generated_id: `ClientGeneratedId${count}`,
+        validations: JSON.stringify(validationsJSONString)
       });
     }
     return databaseResponse;
@@ -46,10 +52,10 @@ describe('patchApplications', () => {
       }
     );
 
-    expect(csvString).toEqual(expect.stringContaining(',1001,'));
+    expect(csvString).toEqual(expect.stringContaining(',1,'));
     expect(csvString).toEqual(expect.stringContaining(',sort code1,'));
     expect(csvString).toEqual(expect.stringContaining(',ClientGeneratedId1'));
-    expect(csvString).toEqual(expect.stringContaining(',1010,'));
+    expect(csvString).toEqual(expect.stringContaining(',10,'));
     expect(csvString).toEqual(expect.stringContaining(',sort code10,'));
     expect(csvString).toEqual(expect.stringContaining(',ClientGeneratedId10'));
   });
@@ -82,5 +88,45 @@ describe('patchApplications', () => {
       /^H,NRGRT,Hackney,\d{2}.\d{2}.\d{4},0,0\n$/
     );
     expect(wholeReportPattern.test(csvString)).toBe(true);
+  });
+
+  test('bank account number is included if validated', async () => {
+    const { container } = createContainerAndDatabaseSpy(1, {
+      businessBankAccount: { accountNumber: true }
+    });
+
+    const { csvString } = await patchApplications(container)({ author: 'foo' });
+
+    expect(csvString).toEqual(expect.stringContaining(',account number1,'));
+  });
+
+  test('bank account number is blank if notvalidated', async () => {
+    const { container } = createContainerAndDatabaseSpy(1, {
+      businessBankAccount: { accountNumber: false }
+    });
+
+    const { csvString } = await patchApplications(container)({ author: 'foo' });
+
+    expect(csvString).toEqual(expect.not.stringContaining(',account number1,'));
+  });
+
+  test('bank sort code is included if validated', async () => {
+    const { container } = createContainerAndDatabaseSpy(1, {
+      businessBankAccount: { accountSortcode: true }
+    });
+
+    const { csvString } = await patchApplications(container)({ author: 'foo' });
+
+    expect(csvString).toEqual(expect.stringContaining(',sort code1,'));
+  });
+
+  test('bank sort code is blank if not validated', async () => {
+    const { container } = createContainerAndDatabaseSpy(1, {
+      businessBankAccount: { accountSortcode: false }
+    });
+
+    const { csvString } = await patchApplications(container)({ author: 'foo' });
+
+    expect(csvString).toEqual(expect.not.stringContaining(',sort code1,'));
   });
 });


### PR DESCRIPTION
**Why**  
To avoid wrong details getting into the payment export help the person doing the payment export spot where correct bank details need entering manually.