### PR TITLE
Add manual permit before staging app and AWS resources deployment and re-deployment.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,16 +109,20 @@ workflows:
   continuous-delivery:
     jobs:
       - install-dependencies-and-test
+      - permit-deploy-staging:
+          type: approval
+          requires:
+            - install-dependencies-and-test
       - assume-role-staging:
           context: api-assume-role-staging-context
           requires:
-            - install-dependencies-and-test
+            - permit-deploy-staging
           filters:
             branches:
               only: master
       - build-deploy-staging:
           requires:
-            - install-dependencies-and-test
+            - permit-deploy-staging
             - assume-role-staging
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,9 @@ workflows:
           type: approval
           requires:
             - install-dependencies-and-test
+          filters:
+            branches:
+              only: master
       - assume-role-staging:
           context: api-assume-role-staging-context
           requires:


### PR DESCRIPTION
# What:
 - Require a manual permit step before staging deployment is triggered.

# Why:
 - To avoid unintentional AWS resource state changes on PR merges.
