### PR TITLE
Sync up Postgres RDS configuration parameters within Serverless YAML.

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -122,6 +122,7 @@ resources:
         DBInstanceClass: "db.t3.micro"
         Engine: "postgres"
         EngineVersion: "11.22"
+        CACertificateIdentifier: "rds-ca-rsa2048-g1"
         MasterUsername: ${env:MASTER_USERNAME}
         MasterUserPassword: ${env:MASTER_USER_PASSWORD}
         VPCSecurityGroups:

--- a/serverless.yml
+++ b/serverless.yml
@@ -121,7 +121,7 @@ resources:
         AllocatedStorage: 5
         DBInstanceClass: "db.t3.micro"
         Engine: "postgres"
-        EngineVersion: "11.21"
+        EngineVersion: "11.22"
         MasterUsername: ${env:MASTER_USERNAME}
         MasterUserPassword: ${env:MASTER_USER_PASSWORD}
         VPCSecurityGroups:

--- a/serverless.yml
+++ b/serverless.yml
@@ -121,7 +121,7 @@ resources:
         AllocatedStorage: 5
         DBInstanceClass: "db.t3.micro"
         Engine: "postgres"
-        EngineVersion: "11.7"
+        EngineVersion: "11.21"
         MasterUsername: ${env:MASTER_USERNAME}
         MasterUserPassword: ${env:MASTER_USER_PASSWORD}
         VPCSecurityGroups:

--- a/serverless.yml
+++ b/serverless.yml
@@ -129,9 +129,12 @@ resources:
           - discretionaryBusinessGrantsDbSecurityGroup
           - GroupId
         Tags:
-          -
-            Key: "Name"
+          - Key: "Name"
             Value: "discretionaryBusinessGrantsDb"
+          - Key: "STAGE"
+            Value: ${self:provider.stage}
+          - Key: "Test"
+            Value: "staging-cci-applied"
       DeletionPolicy: "Snapshot"
 
     CloudFrontDistribution:

--- a/serverless.yml
+++ b/serverless.yml
@@ -119,7 +119,7 @@ resources:
         DBInstanceIdentifier: "discretionary-business-grants-db-${self:provider.stage}"
         DBName: ${self:provider.dbname}
         AllocatedStorage: 5
-        DBInstanceClass: "db.t2.micro"
+        DBInstanceClass: "db.t3.micro"
         Engine: "postgres"
         EngineVersion: "11.7"
         MasterUsername: ${env:MASTER_USERNAME}


### PR DESCRIPTION
# What:
 - Sync up the RDS instance size.
 - Sync up the Postgres engine version.
 - Sync up the Tags.
 - Added a dummy tag.

# Why:
 - Synced up the other RDS parameters so that serverless doesn't try to destroy and re-create the database when the staging pipeline gets triggered.
 - Specified the new certificate version.
 - Dummy tag is for future testing purposes to see whether the changes apply or not to the RDS _(we want as minimal impact for such test as possible)_.

# Notes:
The pipeline may still be blocked due to outdated:
1. lambda node runtime version.
2. pipeline's node version.
3. non-capped serverless version.