### PR TITLE
Remove lambdas configuration

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -76,28 +76,4 @@ resources:
 
 custom:
   bucket: ${self:service}-supporting-documents-${self:provider.stage}
-  domain-name:
-    Fn::Join:
-      - '.'
-      - - Ref: ApiGatewayRestApi
-        - execute-api
-        - eu-west-2
-        - amazonaws.com
-  aliases:
-    staging: staging-discretionarybusinessgrants.hackney.gov.uk
-    production: discretionarybusinessgrants.hackney.gov.uk
-  certificate-arn:
-    staging: arn:aws:acm:us-east-1:715003523189:certificate/b4b3fb9b-febb-493a-bc54-ea8891d68536
-    production: arn:aws:acm:us-east-1:153306643385:certificate/6181c0d4-c6d1-4436-9050-e3a1837aba44
-  subnets:
-    staging:
-      - subnet-07e8364b
-      - subnet-723cb408
-      - subnet-48094621
-    production:
-      - subnet-034b2a03cd4955923
-      - subnet-03431a6c898502c99
-      - subnet-0f02c86bab1d62956
-  allowed-groups:
-    staging: 'DBG - Admin Staging'
-    production: 'DBG - Admins'
+

--- a/serverless.yml
+++ b/serverless.yml
@@ -74,45 +74,6 @@ resources:
             Value: "staging-cci-applied"
       DeletionPolicy: "Snapshot"
 
-    CloudFrontDistribution:
-      Type: AWS::CloudFront::Distribution
-      Properties:
-        DistributionConfig:
-          Aliases:
-            - ${self:custom.aliases.${self:provider.stage}}
-          PriceClass: PriceClass_100
-          ViewerCertificate:
-            AcmCertificateArn: ${self:custom.certificate-arn.${self:provider.stage}}
-            MinimumProtocolVersion: TLSv1.2_2018
-            SslSupportMethod: sni-only
-          DefaultCacheBehavior:
-            TargetOriginId: ${self:service}-${self:provider.stage}-custom-origin
-            ViewerProtocolPolicy: 'redirect-to-https'
-            AllowedMethods:
-              - GET
-              - HEAD
-              - OPTIONS
-              - PUT
-              - PATCH
-              - POST
-              - DELETE
-            DefaultTTL: 0
-            MaxTTL: 0
-            MinTTL: 0
-            ForwardedValues:
-              QueryString: true
-              Cookies:
-                Forward: all
-          Enabled: true
-          Origins:
-            - Id: ${self:service}-${self:provider.stage}-custom-origin
-              DomainName: ${self:custom.domain-name}
-              OriginPath: /${self:provider.stage}
-              CustomOriginConfig:
-                HTTPPort: 80
-                HTTPSPort: 443
-                OriginProtocolPolicy: https-only
-
 custom:
   bucket: ${self:service}-supporting-documents-${self:provider.stage}
   domain-name:

--- a/serverless.yml
+++ b/serverless.yml
@@ -20,52 +20,6 @@ package:
     - ./**
 
 functions:
-  discretionary-business-grants:
-    name: ${self:service}-${self:provider.stage}
-    handler: lambda.handler
-    package:
-      include:
-        - lambda.js
-        - next.config.js
-        - pages/**
-        - public/**
-        - build/_next/**
-        - node_modules/**
-    events:
-      - http:
-          path: api/{proxy+}
-          method: ANY
-          authorizer:
-            name: authorizer
-            type: request
-            identitySource: ''
-            resultTtlInSeconds: 0
-      - http: ANY /
-      - http: ANY /{proxy+}
-    vpc:
-      securityGroupIds:
-        - Fn::GetAtt:
-          - discretionaryBusinessGrantsDbSecurityGroup
-          - GroupId
-      subnetIds: ${self:custom.subnets.${self:provider.stage}}
-    environment:
-      ENV: ${self:provider.stage}
-      HOST:
-        Fn::GetAtt:
-          - discretionaryBusinessGrantsDb
-          - Endpoint.Address
-      USERNAME: ${env:MASTER_USERNAME}
-      PASSWORD: ${env:MASTER_USER_PASSWORD}
-      DATABASE: ${self:provider.dbname}
-      SUPPORTING_DOCUMENTS_BUCKET: ${self:custom.bucket}
-      URL_PREFIX: ${self:custom.aliases.${self:provider.stage}}
-      POSTCODE_LOOKUP_URL: ${env:POSTCODE_LOOKUP_URL}
-      EXPIRATION_DATE: ${env:EXPIRATION_DATE}
-      HACKNERY_AUTH_URL: ${env:HACKNERY_AUTH_URL}
-      POSTCODE_LOOKUP_APIKEY: ${env:POSTCODE_LOOKUP_APIKEY}
-      GOV_NOTIFY_API_KEY: ${env:GOV_NOTIFY_API_KEY}
-      EMAIL_APPLICATION_RECEIVED_TEMPLATE_ID: ${env:EMAIL_APPLICATION_RECEIVED_TEMPLATE_ID}
-
   authorizer:
     name: ${self:service}-authorizer-${self:provider.stage}
     handler: authorizer.handler

--- a/serverless.yml
+++ b/serverless.yml
@@ -2,7 +2,6 @@ service: discretionary-business-grants
 
 provider:
   name: aws
-  runtime: nodejs12.x
   region: eu-west-2
   stage: ${opt:stage}
   dbname: discretionaryBusinessGrantsDb

--- a/serverless.yml
+++ b/serverless.yml
@@ -13,11 +13,6 @@ provider:
         - s3:GetObject
       Resource: "arn:aws:s3:::${self:custom.bucket}/*"
 
-package:
-  individually: true
-  exclude:
-    - ./**
-
 resources:
   Resources:
     discretionaryBusinessGrantsSupportingDocumentsBucket:

--- a/serverless.yml
+++ b/serverless.yml
@@ -19,18 +19,6 @@ package:
   exclude:
     - ./**
 
-functions:
-  authorizer:
-    name: ${self:service}-authorizer-${self:provider.stage}
-    handler: authorizer.handler
-    package:
-      include:
-        - authorizer/**
-        - node_modules/**
-    environment:
-      ALLOWED_GROUPS: ${self:custom.allowed-groups.${self:provider.stage}}
-      JWT_SECRET: ${ssm:hackney-jwt-secret}
-
 resources:
   Resources:
     discretionaryBusinessGrantsSupportingDocumentsBucket:


### PR DESCRIPTION
# What:
 - Removed the AWS Lambda serverless definition.
 - Removed the custom AWS Lambda authoriser definition.
 - Removed the AWS provider serverless runtime configuration.
 - Removed the AWS CloudFront distribution definition.
 - Removed the custom serverless variables used by all of the above.

# Why:
 - The lambda runtime is out of date and no longer supported. Upgrading it would require upgrading the Node.js version of the application and its lambda. This is not worth the hassle when the goal is delete all of the `StagingAPIs` resources due to the environment not being used.
 - We want to remove the serverless lambda runtime option as it will interfere with the deployment of 'Retain' DeletionPolicy against the S3 Bucket.