### PR TITLE
Retire the `StagingAPIs` serverless resources.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,42 +108,44 @@ workflows:
   version: 2
   continuous-delivery:
     jobs:
-      - install-dependencies-and-test
-      - permit-deploy-staging:
-          type: approval
-          requires:
-            - install-dependencies-and-test
+      - assume-role-staging:
+          context: api-assume-role-staging-context
           filters:
             branches:
               only: master
-      - assume-role-staging:
-          context: api-assume-role-staging-context
+      - permit-deploy-staging:
+          type: approval
           requires:
-            - permit-deploy-staging
+            - assume-role-staging
           filters:
             branches:
               only: master
       - build-deploy-staging:
           requires:
             - permit-deploy-staging
-            - assume-role-staging
           filters:
             branches:
               only:
                 - master
-      - permit-deploy-production:
-          type: approval
-          requires:
-            - build-deploy-staging
       - assume-role-production:
           context: api-assume-role-production-context
           requires:
-            - install-dependencies-and-test
-            - permit-deploy-production
+            - build-deploy-staging
           filters:
             branches:
               only: master
+      - permit-deploy-production:
+          type: approval
+          requires:
+            - assume-role-production
+          filters:
+            branches:
+              only:
+                - master
       - build-deploy-production:
           requires:
             - permit-deploy-production
-            - assume-role-production
+          filters:
+            branches:
+              only:
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,21 +16,29 @@ references:
       at: *workspace_root
 
 jobs:
-  build-deploy-staging:
+  deploy-staging:
     executor: aws-cli/default
     steps:
       - *attach_workspace
+      - checkout
       - run:
-          name: deploy
-          command: yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy --stage staging
+          name: install serverless
+          command: sudo npm i -g serverless@^3
+      - run:
+          name: serverless deploy
+          command: sls deploy --stage staging
 
-  build-deploy-production:
+  deploy-production:
     executor: aws-cli/default
     steps:
       - *attach_workspace
+      - checkout
       - run:
-          name: deploy
-          command: yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy -s production
+          name: install serverless
+          command: sudo npm i -g serverless@^3
+      - run:
+          name: serverless deploy
+          command: sls deploy --stage production
 
   assume-role-staging:
     executor: docker-python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,8 @@ jobs:
             aws s3 rm "s3://$bucket_name" --recursive
             aws s3api delete-bucket --bucket "$bucket_name"
       - run:
-          name: serverless deploy
-          command: sls deploy --stage staging
+          name: serverless remove
+          command: sls remove --stage staging --verbose
 
   deploy-production:
     executor: aws-cli/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,19 @@ jobs:
     executor: aws-cli/default
     steps:
       - *attach_workspace
+      - aws-cli/install
       - checkout
       - run:
           name: install serverless
           command: sudo npm i -g serverless@^3
+      - run:
+          name: clear the S3 bucket
+          no_output_timeout: 45m
+          command: |
+            bucket_name="discretionary-business-grants-supporting-documents-staging"
+
+            aws s3 rm "s3://$bucket_name" --recursive
+            aws s3api delete-bucket --bucket "$bucket_name"
       - run:
           name: serverless deploy
           command: sls deploy --stage staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ workflows:
           filters:
             branches:
               only: master
-      - build-deploy-staging:
+      - deploy-staging:
           requires:
             - permit-deploy-staging
           filters:
@@ -92,7 +92,7 @@ workflows:
       - assume-role-production:
           context: api-assume-role-production-context
           requires:
-            - build-deploy-staging
+            - deploy-staging
           filters:
             branches:
               only: master
@@ -104,7 +104,7 @@ workflows:
             branches:
               only:
                 - master
-      - build-deploy-production:
+      - deploy-production:
           requires:
             - permit-deploy-production
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,6 @@ orbs:
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
 
 executors:
-  node-executor:
-    docker:
-      - image: circleci/node:12.9.1-browsers
   docker-python:
     docker:
       - image: circleci/python:3.7
@@ -19,48 +16,6 @@ references:
       at: *workspace_root
 
 jobs:
-  install-dependencies-and-test:
-    executor: node-executor
-    steps:
-      - *attach_workspace
-      - checkout
-      - run:
-          name: Install dependencies
-          command: CYPRESS_CACHE_FOLDER=~/repo/cypress_cache yarn
-
-      #      - aws-cli/install
-      #
-      #      - aws-cli/setup:
-      #          aws-access-key-id: CYPRESS_AWS_ACCESS_KEY_ID
-      #          aws-secret-access-key: CYPRESS_AWS_SECRET_ACCESS_KEY
-      #          aws-region: CYPRESS_AWS_REGION
-
-      - run:
-          name: Build the application
-          command: yarn build
-
-      - run:
-          name: Run unit tests
-          command: yarn run unit-test
-
-      - run:
-          name: Run linting
-          command: yarn lint
-
-      - run:
-          name: Run integration tests
-          command: CYPRESS_CACHE_FOLDER=~/repo/cypress_cache yarn run int-test
-
-      - store_artifacts:
-          path: ~/repo/cypress/screenshots
-
-      - store_artifacts:
-          path: ~/repo/cypress/videos
-
-      - persist_to_workspace:
-          root: *workspace_root
-          paths: .
-
   build-deploy-staging:
     executor: aws-cli/default
     steps:
@@ -71,7 +26,6 @@ jobs:
 
   build-deploy-production:
     executor: aws-cli/default
-
     steps:
       - *attach_workspace
       - run:


### PR DESCRIPTION
# What:
 - Rewire the pipeline to remove dependency on building and testing an application.
 - Remove unused pipeline configuration.
 - Switch from `yarn` to `npm` for installing serverless.
 - Cap serverless to version 3.
 - Make the pipeline trigger the removal of serverless resources on `StagingAPIs` account.
 - Add manual bucket clearing and its deletion step.

# Why:
 - Rewiring to make the pipeline faster and to avoid deprecated node version issues when building an application.
 - We don't need build & test steps of the pipeline when the goal is to decommission resources.
 - Switched to `npm` as it's easier to get serverless working with.
 - Capped serverless to stay under old, unpaid license.
 - Remove the `staging` environment resources as this environment is unused due to the application both having been decommissioned on both `production` and `staging`, but also because there hasn't been any active development done in it for years.
 - Clear the bucket manually as serverless fails to delete the S3 bucket whilst it has files left in it.

# Notes:
 - The serverless-managed `discretionary-business-grants-db-staging` AWS RDS postgres database instance that will get destroyed by these changes already has a couple snapshots under the names of: `discretionary-business-grants-db-staging-16-03-2022`, and `discretionary-business-grants-db-staging-manual-snap`. However, the CF Deletion Policy on it will make another 'final' snapshot regardless _(a way to avoid this would be to 1st deploy a different deletion policy, but it's not worth the effort)_.
 - The `discretionary-business-grants-supporting-documents-staging` AWS S3 bucket doesn't have any data of value - it's all just random files the original developers of the application uploaded whilst testing the application. So the S3 bucket will be deleted. Probably could delete the AWS RDS snapshots for the same reason as that data links to the bucket, however, that's not the decommissioning policy our team has agreed on thus far.
 - The only `staging` AWS RDS postgres instance connection over last 15 months made was me checking out what kind of data is being held there [[link](https://docs.google.com/document/d/1X1vrdjhqAB3P85NPokvLYl8TqvM8UDk7JKymJkIA-so/edit?usp=sharing)].

# Screenshots:

| The staging S3 bucket | The staging RDS database connections over last 15 months |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/63772a40-adea-4baa-a954-d85df9e597ad) | ![image](https://github.com/user-attachments/assets/dc1e1340-ea34-4933-97b3-50311a9b517b) |
