### PR TITLE
Add DeletionPolicy Retain, and Enable Versioning for the S3 bucket.

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -59,6 +59,7 @@ resources:
         DBName: ${self:provider.dbname}
         AllocatedStorage: 5
         DBInstanceClass: "db.t3.micro"
+        DeletionProtection: false
         Engine: "postgres"
         EngineVersion: "11.22"
         CACertificateIdentifier: "rds-ca-rsa2048-g1"

--- a/serverless.yml
+++ b/serverless.yml
@@ -73,8 +73,8 @@ resources:
             Value: "discretionaryBusinessGrantsDb"
           - Key: "STAGE"
             Value: ${self:provider.stage}
-          - Key: "Test"
-            Value: "staging-cci-applied"
+          - Key: "BackupPolicy"
+            Value: "Prod"
       DeletionPolicy: "Snapshot"
 
 custom:

--- a/serverless.yml
+++ b/serverless.yml
@@ -16,29 +16,32 @@ provider:
 resources:
   Resources:
     discretionaryBusinessGrantsSupportingDocumentsBucket:
-        Type: AWS::S3::Bucket
-        Properties:
-          BucketName: ${self:custom.bucket}
-          PublicAccessBlockConfiguration:
-            BlockPublicAcls: true
-            BlockPublicPolicy: true
-            IgnorePublicAcls: true
-            RestrictPublicBuckets: true
-          BucketEncryption:
-            ServerSideEncryptionConfiguration:
-              - ServerSideEncryptionByDefault:
-                  SSEAlgorithm: AES256
-          CorsConfiguration:
-            CorsRules:
-              -
-                AllowedOrigins:
-                  - '*'
-                AllowedHeaders:
-                  - '*'
-                AllowedMethods:
-                  - PUT
-                  - POST
-                MaxAge: 3000
+      Type: AWS::S3::Bucket
+      DeletionPolicy: Retain
+      Properties:
+        BucketName: ${self:custom.bucket}
+        PublicAccessBlockConfiguration:
+          BlockPublicAcls: true
+          BlockPublicPolicy: true
+          IgnorePublicAcls: true
+          RestrictPublicBuckets: true
+        BucketEncryption:
+          ServerSideEncryptionConfiguration:
+            - ServerSideEncryptionByDefault:
+                SSEAlgorithm: AES256
+        VersioningConfiguration:
+          Status: Enabled
+        CorsConfiguration:
+          CorsRules:
+            -
+              AllowedOrigins:
+                - '*'
+              AllowedHeaders:
+                - '*'
+              AllowedMethods:
+                - PUT
+                - POST
+              MaxAge: 3000
     discretionaryBusinessGrantsDbSecurityGroup:
       Type: AWS::EC2::SecurityGroup
       Properties:

--- a/serverless.yml
+++ b/serverless.yml
@@ -76,7 +76,7 @@ resources:
             Value: ${self:provider.stage}
           - Key: "BackupPolicy"
             Value: "Prod"
-      DeletionPolicy: "Snapshot"
+      DeletionPolicy: Delete
 
 custom:
   bucket: ${self:service}-supporting-documents-${self:provider.stage}


### PR DESCRIPTION
# What:
 - Give `DeletionPolicy: 'Retain'` for the supporting documents S3 bucket within the `discretionary-business-grants` CF stack.
 - Give the `Versioning: Enabled` option to this S3 bucket.
 - Tweak indentation of the S3 definition block.

# Why:
 - Added Deletion Policy Retain to further reduce the chances of the bucket getting deleted even though the existence of files should make the deletion fail already _(ignoring the versioning aspect)_.
 - The S3 bucket file versioning has been enabled manually via AWS console, however, this change was not added to the serverless config. So added this option to the config so that when the deployment is made that it wouldn't remove the versioning from the bucket.
 - Tweaked the indent so it doesn't stand out from the rest of the serverless config.

# Notes:
 - The database manual snapshot was taken under the name of discretionary-business-grants-db-production-not-used-in-half-year-6cons-in15mo-snapshot` so the deletion policy change doesn't have consequences.