### PR TITLE
Deploy the `Retain` DeletionPolicy on the S3 supporting documents bucket.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ jobs:
       - run:
           name: serverless deploy
           command: sls deploy --stage production
+          no_output_timeout: 45m
 
   assume-role-production:
     executor: docker-python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,27 +16,6 @@ references:
       at: *workspace_root
 
 jobs:
-  deploy-staging:
-    executor: aws-cli/default
-    steps:
-      - *attach_workspace
-      - aws-cli/install
-      - checkout
-      - run:
-          name: install serverless
-          command: sudo npm i -g serverless@^3
-      - run:
-          name: clear the S3 bucket
-          no_output_timeout: 45m
-          command: |
-            bucket_name="discretionary-business-grants-supporting-documents-staging"
-
-            aws s3 rm "s3://$bucket_name" --recursive
-            aws s3api delete-bucket --bucket "$bucket_name"
-      - run:
-          name: serverless remove
-          command: sls remove --stage staging --verbose
-
   deploy-production:
     executor: aws-cli/default
     steps:
@@ -48,19 +27,6 @@ jobs:
       - run:
           name: serverless deploy
           command: sls deploy --stage production
-
-  assume-role-staging:
-    executor: docker-python
-    steps:
-      - checkout
-      - aws_assume_role/assume_role:
-          account: $AWS_ACCOUNT_STAGING
-          profile_name: default
-          role: "LBH_Circle_CI_Deployment_Role"
-      - persist_to_workspace:
-          root: *workspace_root
-          paths:
-            - .aws
 
   assume-role-production:
     executor: docker-python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,8 +100,6 @@ workflows:
                 - master
       - assume-role-production:
           context: api-assume-role-production-context
-          requires:
-            - deploy-staging
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           command: sudo npm i -g serverless@^3
       - run:
           name: serverless deploy
-          command: sls deploy --stage production
+          command: sls deploy --stage production --verbose
           no_output_timeout: 45m
 
   assume-role-production:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,25 +79,6 @@ workflows:
   version: 2
   continuous-delivery:
     jobs:
-      - assume-role-staging:
-          context: api-assume-role-staging-context
-          filters:
-            branches:
-              only: master
-      - permit-deploy-staging:
-          type: approval
-          requires:
-            - assume-role-staging
-          filters:
-            branches:
-              only: master
-      - deploy-staging:
-          requires:
-            - permit-deploy-staging
-          filters:
-            branches:
-              only:
-                - master
       - assume-role-production:
           context: api-assume-role-production-context
           filters:


### PR DESCRIPTION
# What:
 - **Trigger** deployment changes mentioned in the **notes**.
 - Remove staging references from the CircleCI pipeline.

# Why:
 - The `StagingAPIs` environment has been fully decommissioned.
 - Allows going straight into the `production` workflow.

# Notes:
 - [Deployment changes] Add the `DeletionPolicy: Retain` against the `discretionary-business-grants-supporting-documents-production` S3 bucket.
 - [Deployment changes] Remove the `DeletionProtection` from the `discretionary-business-grants-db-production` and change its `DeletionPolicy` to `Delete` as the manual snapshot was already created under the name of: `discretionary-business-grants-db-production-not-used-in-half-year-6cons-in15mo-snapshot`.
 - [Deployment changes] This should try to remove the AWS Lambda of the application and its authorizer.
 - [Deployment changes] This should try to remove the CloudFront distribution setup.
 - These removals are justified because the application has been decommissioned long before this point & so there's no need to keep these resources running.

# Screenshots:

| Staging application URL inaccessible | Production application URL decommissioned |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/8c58cddd-7133-4bfe-be77-b9f355be7873) | ![image](https://github.com/user-attachments/assets/6ca5c450-a68b-494f-b25a-a8cce455caff) |

| Last application logs end on May | The production database hasn't received connections for half a year |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/11d392d1-034e-46ed-bf2b-09298477f7d3) | ![image](https://github.com/user-attachments/assets/fa59b177-fbee-447b-b302-44fb2a6cb3ca) |