### PR TITLE
Retire the `ProductionAPIs` CloudFormation resources, except Supporting Documents S3 bucket.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           command: sudo npm i -g serverless@^3
       - run:
           name: serverless deploy
-          command: sls deploy --stage production --verbose
+          command: sls remove --stage production --verbose
           no_output_timeout: 45m
 
   assume-role-production:


### PR DESCRIPTION
# What:
 - Trigger the `ProductionAPIs` Cloud Formatoin stack resource destruction, except S3.

# Why:
 - The application has been decommissioned _(See PR #260 description)_.

# Notes:
 - The bucket will be retained by the deletion policy.
 - The RDS snapshot name is in the above linked PR.
